### PR TITLE
Graphviz patch for windows users

### DIFF
--- a/fall19/lab-p4/README.md
+++ b/fall19/lab-p4/README.md
@@ -48,7 +48,7 @@ Sometimes, when a program requires many different packages, developers like to l
 pip install -r requirements.txt
 ```
 
-Note: If you working on windows system, you also need to download and install graphviz from [here](https://graphviz.gitlab.io/_pages/Download/Download_windows.html), Uncomment the lines in the gen_tree.py which mentions the path of graphviz. Edit the path if its different for your system.
+Note: If you are working on windows system, you also need to download and install graphviz from [here](https://graphviz.gitlab.io/_pages/Download/Download_windows.html), Uncomment the lines in the gen_tree.py which mentions the path of graphviz. Edit the path if its different for your system.
 
 ## Download
 

--- a/fall19/lab-p4/README.md
+++ b/fall19/lab-p4/README.md
@@ -48,6 +48,8 @@ Sometimes, when a program requires many different packages, developers like to l
 pip install -r requirements.txt
 ```
 
+Note: If you working on windows system, you also need to download and install graphviz from [here](https://graphviz.gitlab.io/_pages/Download/Download_windows.html), Uncomment the lines in the gen_tree.py which mentions the path of graphviz. Edit the path if its different for your system.
+
 ## Download
 
 Download the following to a new directory named `lab-p4` (remember to

--- a/fall19/lab-p4/gen_tree.py
+++ b/fall19/lab-p4/gen_tree.py
@@ -5,6 +5,11 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.tree import export_graphviz
 from sklearn.tree._tree import TREE_LEAF
 
+# Download and install graphviz from https://graphviz.gitlab.io/_pages/Download/Download_windows.html
+# Uncomment the following and edit the path of the graphviz if its different for your machine
+# import os
+# os.environ["PATH"] += os.pathsep + 'C:/Program Files (x86)/Graphviz2.38/bin/'
+
 # draw decision tree and save it to filename
 def dump_decision_tree(clf, feature_cols, filename):
     dot_data = io.StringIO()


### PR DESCRIPTION
WIndows users get 'InvocationException: GraphViz's executables not found'.
Add instructions to download and install graphviz. Path is graphviz is added in environment using python file.