### PR TITLE
Fixed comments bug in linter

### DIFF
--- a/linter/README.md
+++ b/linter/README.md
@@ -4,6 +4,8 @@
 
 * Nov 20: Please re-download latest lint.py as there was an issue with jupyter 
 magics such as (%matplotlib inline)
+* Nov 23: Fixed a small bug that created unnecessary "Statement seems to have 
+no effect" errors.
 
 ## Introduction
 

--- a/linter/lint.py
+++ b/linter/lint.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 import nbformat
 import numpy as np
 from pylint import epylint
+import astroid
 
 
 class LintMessage:
@@ -146,6 +147,10 @@ class NotebookLinter(ScriptLinter):
                 cleaned_source.append(line)
         return '\n'.join(cleaned_source)
 
+    @staticmethod
+    def remove_comments(source):
+        return astroid.parse(source).as_string().strip()
+
     def is_not_jupyter_magic(self, msg):
         is_magic = self.line_is_jupyter_magic(msg.data)
         is_error = msg.msg_id == "E0001"
@@ -157,7 +162,9 @@ class NotebookLinter(ScriptLinter):
 
     def last_line_of_code(self, msg):
         cell_str = self.cells[msg.cell]
-        return cell_str.strip().endswith(msg.data)
+        cell_str = self.remove_comments(cell_str)
+        line_str = self.remove_comments(msg.data)
+        return cell_str.endswith(line_str)
 
     def filter_messages(self, msgs):
         """Filter messages that might have been created due to


### PR DESCRIPTION
Small tweak to further suppress "useless statement" warnings when comments are at the end of a cell.