### PR TITLE
Changed "ratio" to "gap"

### DIFF
--- a/fall19/p10/stage2.md
+++ b/fall19/p10/stage2.md
@@ -99,7 +99,7 @@ Make sure to include the "other" category.
 
 #### Question 28: What are the top 15 countries that have the largest gap between birth rate and death rate?
 
-You should display the `country` name, `birth-rate`, and `death-rate` of the top 15 countries that have the largest gap between `birth-rate` and `death-rate`. These top 15 countries should be displayed in *descending* order of the ratio.
+You should display the `country` name, `birth-rate`, and `death-rate` of the top 15 countries that have the largest gap between `birth-rate` and `death-rate`. These top 15 countries should be displayed in *descending* order of the gap.
 
 **Expected output:**
 


### PR DESCRIPTION
Changed the word "ratio" to "gap" for describing the birth and death rate gap. Saying "ratio" could imply that we are looking for the ratio between the rates rather than the difference.